### PR TITLE
Add colorama as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 ]
 dependencies = [
     "aiohttp==3.9.5",
+    "colorama==0.4.6",
     "platformdirs==4.2.2",
     "pyserial==3.5",
     "python-socketio[asyncio_client]==5.11.3",


### PR DESCRIPTION
**Brief summary of changes**

- Nuitka is worse than PyInstaller at the moment

**Notes**
